### PR TITLE
Ability to resize the Advanced Options Panel

### DIFF
--- a/DistrictEnergy/DistrictControl.xaml
+++ b/DistrictEnergy/DistrictControl.xaml
@@ -73,13 +73,7 @@
                 <resultViews:Loads Margin="0,5,0,0"/>
             </TabItem>
         </dragablz:TabablzControl>
-        <Grid Grid.Row="3" Grid.Column="0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="50*" />
-                <ColumnDefinition Width="50*" />
-            </Grid.ColumnDefinitions>
-            <Button Click="RunSimulationClick" Margin="5,0" Content="Run Simulation" Grid.ColumnSpan="2" />
-        </Grid>
+        <Button Click="RunSimulationClick" Margin="5,0" Content="Run Simulation" Grid.Row="3"/>
         <Expander Grid.Row="4" Grid.Column="0" Header="Advanced Options"
                   Style="{DynamicResource MaterialDesignExpander}" HorizontalContentAlignment="Stretch">
             <ScrollViewer Height="500">

--- a/DistrictEnergy/DistrictControl.xaml
+++ b/DistrictEnergy/DistrictControl.xaml
@@ -34,49 +34,55 @@
                     Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/materialdesign.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <Style TargetType="{x:Type dragablz:TabablzControl}" BasedOn="{StaticResource MaterialDesignTabablzControlStyle}" />
+            <Style TargetType="{x:Type dragablz:TabablzControl}"
+                   BasedOn="{StaticResource MaterialDesignTabablzControlStyle}" />
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid>
+    <Grid Name="expanderGrid">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="50*" />
-            <RowDefinition Height="50*" />
-            <RowDefinition Height="32" />
-            <RowDefinition Height="auto" />
+            <RowDefinition Height="Auto" /><!-- Scenarios -->
+            <RowDefinition /><!-- Charts -->
+            <RowDefinition Height="Auto" /><!-- GridSplitter -->
+            <RowDefinition Height="Auto" /><!-- Button -->
+            <RowDefinition /><!-- Expander -->
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="100*" />
-        </Grid.ColumnDefinitions>
-        <StackPanel>
-            <ComboBox x:Name="SelectSimCase" Width="Auto" ItemsSource="{Binding SimCases}" Margin="5"
-                      SelectedItem="{Binding ASimCase}" materialDesign:HintAssist.Hint="Choose A Scenario"
-                      Style="{StaticResource MaterialDesignComboBox}"
-                      DisplayMemberPath="DName">
-                <ComboBox.DataContext>
-                    <vm:DistrictSettingsViewModel />
-                </ComboBox.DataContext>
-            </ComboBox>
-        </StackPanel>
-        <dragablz:TabablzControl Grid.Column="0" Grid.Row="1" Grid.RowSpan="2" Margin="5">
+        <ComboBox x:Name="SelectSimCase" Width="Auto" ItemsSource="{Binding SimCases}" Margin="5"
+                  SelectedItem="{Binding ASimCase}" materialDesign:HintAssist.Hint="Choose A Scenario"
+                  Style="{StaticResource MaterialDesignComboBox}" Grid.Row="0"
+                  DisplayMemberPath="DName">
+            <ComboBox.DataContext>
+                <vm:DistrictSettingsViewModel />
+            </ComboBox.DataContext>
+        </ComboBox>
+
+
+        <dragablz:TabablzControl Grid.Row="1" Margin="5">
             <TabItem Header="Costs">
                 <resultViews:Costs Margin="0,5,0,0" />
             </TabItem>
             <TabItem Header="Carbon">
-                <resultViews:Carbon Margin="0,5,0,0"/>
+                <resultViews:Carbon Margin="0,5,0,0" />
             </TabItem>
             <TabItem Header="Fuel">
-                <resultViews:Fuel Margin="0,5,0,0"/>
+                <resultViews:Fuel Margin="0,5,0,0" />
             </TabItem>
             <TabItem Header="Loads">
-                <resultViews:Loads Margin="0,5,0,0"/>
+                <resultViews:Loads Margin="0,5,0,0" />
             </TabItem>
         </dragablz:TabablzControl>
-        <Button Click="RunSimulationClick" Margin="5,0" Content="Run Simulation" Grid.Row="3"/>
-        <Expander Grid.Row="4" Grid.Column="0" Header="Advanced Options"
-                  Style="{DynamicResource MaterialDesignExpander}" HorizontalContentAlignment="Stretch">
-            <ScrollViewer Height="500">
+
+
+        <GridSplitter Grid.Row="2" Name="splitter"
+                      ResizeDirection="Rows" VerticalContentAlignment="Bottom"
+                      HorizontalAlignment="Stretch" Height="5" />
+
+
+        <Button Click="RunSimulationClick" Margin="5,5" Content="Run Simulation" Grid.Row="3" />
+        <Expander Header="Advanced Options" x:Name="MyExpander" IsExpanded="False" Grid.Row="4"
+                  Style="{DynamicResource MaterialDesignExpander}" HorizontalContentAlignment="Stretch"
+                  Expanded="ExpandedOrCollapsed">
+            <ScrollViewer>
                 <StackPanel>
                     <plantSettings:NetworkView Height="auto" />
                     <plantSettings:AbsorptionChillerView Height="auto" />
@@ -86,6 +92,7 @@
                 </StackPanel>
             </ScrollViewer>
         </Expander>
+
     </Grid>
 
 </UserControl>

--- a/DistrictEnergy/DistrictControl.xaml
+++ b/DistrictEnergy/DistrictControl.xaml
@@ -41,15 +41,14 @@
 
     <Grid Name="expanderGrid">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" /><!-- Scenarios -->
-            <RowDefinition /><!-- Charts -->
+            <RowDefinition Height="Auto"/><!-- Scenarios -->
+            <RowDefinition Height="2*"/><!-- LiveChart -->
             <RowDefinition Height="Auto" /><!-- GridSplitter -->
-            <RowDefinition Height="Auto" /><!-- Button -->
-            <RowDefinition /><!-- Expander -->
+            <RowDefinition /><!-- Button --><!-- Expander -->
         </Grid.RowDefinitions>
         <ComboBox x:Name="SelectSimCase" Width="Auto" ItemsSource="{Binding SimCases}" Margin="5"
                   SelectedItem="{Binding ASimCase}" materialDesign:HintAssist.Hint="Choose A Scenario"
-                  Style="{StaticResource MaterialDesignComboBox}" Grid.Row="0"
+                  Style="{StaticResource MaterialDesignComboBox}"
                   DisplayMemberPath="DName">
             <ComboBox.DataContext>
                 <vm:DistrictSettingsViewModel />
@@ -57,7 +56,7 @@
         </ComboBox>
 
 
-        <dragablz:TabablzControl Grid.Row="1" Margin="5">
+        <dragablz:TabablzControl Margin="5" Grid.Row="1">
             <TabItem Header="Costs">
                 <resultViews:Costs Margin="0,5,0,0" />
             </TabItem>
@@ -78,20 +77,26 @@
                       HorizontalAlignment="Stretch" Height="5" />
 
 
-        <Button Click="RunSimulationClick" Margin="5,5" Content="Run Simulation" Grid.Row="3" />
-        <Expander Header="Advanced Options" x:Name="MyExpander" IsExpanded="False" Grid.Row="4"
-                  Style="{DynamicResource MaterialDesignExpander}" HorizontalContentAlignment="Stretch"
-                  Expanded="ExpandedOrCollapsed">
-            <ScrollViewer>
-                <StackPanel>
-                    <plantSettings:NetworkView Height="auto" />
-                    <plantSettings:AbsorptionChillerView Height="auto" />
-                    <plantSettings:HotWaterView Height="auto" />
-                    <plantSettings:ElectricGenerationView Height="auto" />
-                    <plantSettings:CombinedHeatAndPowerView Height="auto" />
-                </StackPanel>
-            </ScrollViewer>
-        </Expander>
+        <Grid Grid.Row="3">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <Button Click="RunSimulationClick" Margin="5,5" Content="Run Simulation" />
+            <Expander Header="Advanced Options" x:Name="MyExpander" IsExpanded="False"
+                      Style="{DynamicResource MaterialDesignExpander}" HorizontalContentAlignment="Stretch"
+                      Expanded="ExpandedOrCollapsed" Grid.Row="1">
+                <ScrollViewer Height="Auto">
+                    <StackPanel>
+                        <plantSettings:NetworkView Height="auto" />
+                        <plantSettings:AbsorptionChillerView Height="auto" />
+                        <plantSettings:HotWaterView Height="auto" />
+                        <plantSettings:ElectricGenerationView Height="auto" />
+                        <plantSettings:CombinedHeatAndPowerView Height="auto" />
+                    </StackPanel>
+                </ScrollViewer>
+            </Expander>
+        </Grid>
 
     </Grid>
 

--- a/DistrictEnergy/DistrictControl.xaml.cs
+++ b/DistrictEnergy/DistrictControl.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Media;
 using DistrictEnergy.Annotations;
 using DistrictEnergy.Helpers;
 using DistrictEnergy.Networks.ThermalPlants;
@@ -46,8 +47,9 @@ namespace DistrictEnergy
             NetworkViewModel.Instance.PropertyChanged += OnCustomPropertyChanged;
 
             starHeight = new GridLength[expanderGrid.RowDefinitions.Count];
+            starHeight[0] = expanderGrid.RowDefinitions[0].Height;
             starHeight[1] = expanderGrid.RowDefinitions[1].Height;
-            starHeight[4] = expanderGrid.RowDefinitions[4].Height;
+            starHeight[3] = expanderGrid.RowDefinitions[3].Height;
 
             ExpandedOrCollapsed(MyExpander);
             // InitializeComponent calls topExpander.Expanded
@@ -212,18 +214,21 @@ namespace DistrictEnergy
 
         void ExpandedOrCollapsed(Expander expander)
         {
-            var rowIndex = Grid.GetRow(expander);
-            var row = expanderGrid.RowDefinitions[rowIndex];
-            if (expander.IsExpanded)
+            if (expander.Parent is Grid grid)
             {
-                row.Height = starHeight[rowIndex];
-                row.MinHeight = 88;
-            }
-            else
-            {
-                starHeight[rowIndex] = row.Height;
-                row.Height = GridLength.Auto;
-                row.MinHeight = 0;
+                var rowIndex = Grid.GetRow(grid);
+                var row = expanderGrid.RowDefinitions[rowIndex];
+                if (expander.IsExpanded)
+                {
+                    row.Height = starHeight[rowIndex];
+                    row.MinHeight = 88;
+                }
+                else
+                {
+                    starHeight[rowIndex] = row.Height;
+                    //row.Height = GridLength.Auto;
+                    row.MinHeight = 0;
+                }
             }
 
             var isExpanded = MyExpander.IsExpanded;

--- a/DistrictEnergy/DistrictControl.xaml.cs
+++ b/DistrictEnergy/DistrictControl.xaml.cs
@@ -206,7 +206,11 @@ namespace DistrictEnergy
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
-
+        /// <summary>
+        /// See http://csuporj2.blogspot.com/2009/12/wpf-expanders-with-stretching-height.html for more information
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void ExpandedOrCollapsed(object sender, RoutedEventArgs e)
         {
             ExpandedOrCollapsed(sender as Expander);
@@ -226,7 +230,7 @@ namespace DistrictEnergy
                 else
                 {
                     starHeight[rowIndex] = row.Height;
-                    //row.Height = GridLength.Auto;
+                    row.Height = GridLength.Auto;
                     row.MinHeight = 0;
                 }
             }

--- a/DistrictEnergy/DistrictControl.xaml.cs
+++ b/DistrictEnergy/DistrictControl.xaml.cs
@@ -44,6 +44,27 @@ namespace DistrictEnergy
             ElectricGenerationViewModel.Instance.PropertyChanged += OnCustomPropertyChanged;
             HotWaterViewModel.Instance.PropertyChanged += OnCustomPropertyChanged;
             NetworkViewModel.Instance.PropertyChanged += OnCustomPropertyChanged;
+
+            starHeight = new GridLength[expanderGrid.RowDefinitions.Count];
+            starHeight[1] = expanderGrid.RowDefinitions[1].Height;
+            starHeight[4] = expanderGrid.RowDefinitions[4].Height;
+
+            ExpandedOrCollapsed(MyExpander);
+            // InitializeComponent calls topExpander.Expanded
+            // while bottomExpander is null, if we hook this up in the xaml
+            MyExpander.Expanded += ExpandedOrCollapsed;
+            MyExpander.Collapsed += ExpandedOrCollapsed;
+        }
+
+        private double _minHeight;
+        public double MinHeight
+        {
+            get { return _minHeight; }
+            set
+            {
+                _minHeight = value;
+                OnPropertyChanged("MinHeight");
+            }
         }
 
         private void OnCustomPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -164,6 +185,8 @@ namespace DistrictEnergy
             OnPropertyChanged();
         }
 
+        GridLength[] starHeight;
+
         private void CostsChecked(object sender, RoutedEventArgs e)
         {
             if (DHSimulateDistrictEnergy.Instance == null) return;
@@ -180,6 +203,32 @@ namespace DistrictEnergy
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private void ExpandedOrCollapsed(object sender, RoutedEventArgs e)
+        {
+            ExpandedOrCollapsed(sender as Expander);
+        }
+
+        void ExpandedOrCollapsed(Expander expander)
+        {
+            var rowIndex = Grid.GetRow(expander);
+            var row = expanderGrid.RowDefinitions[rowIndex];
+            if (expander.IsExpanded)
+            {
+                row.Height = starHeight[rowIndex];
+                row.MinHeight = 88;
+            }
+            else
+            {
+                starHeight[rowIndex] = row.Height;
+                row.Height = GridLength.Auto;
+                row.MinHeight = 0;
+            }
+
+            var isExpanded = MyExpander.IsExpanded;
+            splitter.Visibility = isExpanded ?
+                Visibility.Visible : Visibility.Collapsed;
         }
     }
 


### PR DESCRIPTION
Previously, opening the advanced options panel would open upwards and reduce the size of the Results area (charts). This pull-requests adds a GridSplitter which allows users to resize the bottom panel when it is expanded.

![Added GridSplitter](https://user-images.githubusercontent.com/22966009/79535112-7d849e80-804a-11ea-97a2-75bb8bd371b1.png)

This also fixes issue #31 where the scroll view would continue past the bottom of the window on narrow screens.