### PR TITLE
Adds Excess Heating/Cooling placeholders as "expensive" variables

### DIFF
--- a/DistrictEnergy/DHRunLPModel.cs
+++ b/DistrictEnergy/DHRunLPModel.cs
@@ -52,7 +52,7 @@ namespace DistrictEnergy
         {
             DHSimulateDistrictEnergy.Instance.PreSolve();
             // Create the linear solver with the CBC backend.
-            var solver = Solver.CreateSolver("SimpleMipProgram", "GLOP_LINEAR_PROGRAMMING");
+            var solver = Solver.CreateSolver("SimpleLP", "GLOP_LINEAR_PROGRAMMING");
 
             // Define Model Variables. Here each variable is the supply power of each available supply module
             int timeSteps = (int) DistrictControl.PlanningSettings.TimeSteps; // Number of Time Steps

--- a/DistrictEnergy/DHRunLPModel.cs
+++ b/DistrictEnergy/DHRunLPModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DistrictEnergy.Helpers;
@@ -15,31 +15,27 @@ namespace DistrictEnergy
         public DHRunLPModel()
         {
             Instance = this;
-            Qin = new Dictionary<(int, IThermalPlantSettings), Variable>();
-            Qout = new Dictionary<(int, IThermalPlantSettings), Variable>();
-            S = new Dictionary<(int, IThermalPlantSettings), Variable>();
-            P = new Dictionary<(int, IThermalPlantSettings), Variable>();
         }
 
         /// <summary>
         /// Input energy flow at each supply module of the energy hub at each time step"
         /// </summary>
-        public Dictionary<(int, IThermalPlantSettings), Variable> P { get; set; }
+        public Dictionary<(int, IThermalPlantSettings), Variable> P { get; set; } = new Dictionary<(int, IThermalPlantSettings), Variable>();
 
         /// <summary>
         /// Storage state at each storage module of the energy hub at each time step"
         /// </summary>
-        public Dictionary<(int, IThermalPlantSettings), Variable> S { get; set; }
+        public Dictionary<(int, IThermalPlantSettings), Variable> S = new Dictionary<(int, IThermalPlantSettings), Variable>();
 
         /// <summary>
         /// Output energy flow at each storage module of the energy hub at each time step"
         /// </summary>
-        public Dictionary<(int, IThermalPlantSettings), Variable> Qout { get; set; }
+        public Dictionary<(int, IThermalPlantSettings), Variable> Qout = new Dictionary<(int, IThermalPlantSettings), Variable>();
 
         /// <summary>
         /// Input energy flow at each storage module of the energy hub at each time step"
         /// </summary>
-        public Dictionary<(int, IThermalPlantSettings), Variable> Qin { get; set; }
+        public Dictionary<(int, IThermalPlantSettings), Variable> Qin = new Dictionary<(int, IThermalPlantSettings), Variable>();
 
         ///<summary>The only instance of the DHRunLPModel command.</summary>
         public static DHRunLPModel Instance { get; private set; }

--- a/DistrictEnergy/Properties/AssemblyInfo.cs
+++ b/DistrictEnergy/Properties/AssemblyInfo.cs
@@ -24,7 +24,7 @@ using Rhino.PlugIns;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: AssemblyProduct("DistricEnergyPlugIn")]
-[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyVersion("2.0.1.*")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/SetupProject/DistrictPlugInInstaller.wixproj
+++ b/SetupProject/DistrictPlugInInstaller.wixproj
@@ -6,7 +6,7 @@
     <ProductVersion>3.10</ProductVersion>
     <ProjectGuid>2a10a76b-558f-424d-965b-d2c84703cee0</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>DistrictPluginInstaller-4.433-2020-dev-2.0.0-beta6</OutputName>
+    <OutputName>DistrictPluginInstaller-4.433-2020-dev-2.0.1</OutputName>
     <OutputType>Package</OutputType>
     <Name>DistrictPlugInInstaller</Name>
   </PropertyGroup>


### PR DESCRIPTION
When excess heat is generated (e.g too large solar array or too large additional load), it will be added to an Export variable. There are now 3, one for each main loadtypes (heating, cooling, electricity)