### PR TITLE
Capacities defined as annual total energy supplied by the whole energy hub

### DIFF
--- a/DistrictEnergy/Networks/ThermalPlants/AbsorptionChiller.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/AbsorptionChiller.cs
@@ -63,6 +63,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType { get; } = LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Heating;
+        public override double CapacityFactor => OFF_ABS;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/BatteryBank.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/BatteryBank.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
@@ -63,5 +64,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override double MaxChargingRate => Capacity > 0 ? Capacity / AUT_BAT : 0;
         public override double MaxDischargingRate => Capacity > 0 ? Capacity / AUT_BAT : 0;
         public override double StartingCapacity => Capacity * BAT_START;
+        public override double Capacity => CalcCapacity();
+        private double CalcCapacity()
+        {
+            return DistrictControl.Instance.ListOfDistrictLoads.Where(x => x.LoadType == LoadTypes.Elec).Select(v => v.Input.Average()).Sum() * AUT_BAT * 24;
+        }
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
@@ -88,6 +88,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.Gas;
+        public override double CapacityFactor => OFF_CHP;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
@@ -29,6 +29,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public double[] Used = new double[8760];
         public override LoadTypes OutputType => LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Custom;
+        public override double CapacityFactor => 1;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
@@ -18,6 +18,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.Custom;
+        public override double CapacityFactor => 1;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
@@ -103,6 +103,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
             set => throw new NotImplementedException();
         }
 
+        public override double CapacityFactor { get; }
+
         public Color Color { get; set; } = Color.FromRgb(200, 1, 0);
         public abstract override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public abstract override double Efficiency { get; }

--- a/DistrictEnergy/Networks/ThermalPlants/CustomHeatingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomHeatingSupplyModule.cs
@@ -16,6 +16,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Custom;
+        public override double CapacityFactor => 1;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
@@ -25,6 +25,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public GraphCost FixedCost => new FixedCost(this);
         public GraphCost VariableCost => new VariableCost(this, 200);
         public double TotalCost => FixedCost.Cost + VariableCost.Cost;
+        public abstract double CapacityFactor { get; }
     }
 
     public class FixedCost : GraphCost

--- a/DistrictEnergy/Networks/ThermalPlants/ElectricChiller.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ElectricChiller.cs
@@ -33,6 +33,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; }
         public override LoadTypes OutputType => LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Elec;
+        public override double CapacityFactor => 1;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/ElectricHeatPump.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ElectricHeatPump.cs
@@ -58,6 +58,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Elec;
+        public override double CapacityFactor => OFF_EHP;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/GridElectricity.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/GridElectricity.cs
@@ -38,6 +38,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.GridElec;
+        public override double CapacityFactor => 1;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/GridGas.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/GridGas.cs
@@ -36,6 +36,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Gas;
         public override LoadTypes InputType => LoadTypes.GridGas;
+        public override double CapacityFactor => 1;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/HotWaterStorage.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/HotWaterStorage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
@@ -55,5 +56,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override double MaxChargingRate => Capacity > 0 ? Capacity / AUT_HWT : 0;
         public override double MaxDischargingRate => Capacity > 0 ? Capacity / AUT_HWT : 0;
         public override double StartingCapacity => Capacity * TANK_START;
+        public override double Capacity => CalcCapacity();
+        private double CalcCapacity()
+        {
+            return DistrictControl.Instance.ListOfDistrictLoads.Where(x => x.LoadType == LoadTypes.Heating).Select(v => v.Input.Average()).Sum() * AUT_HWT * 24;
+        }
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
@@ -68,5 +68,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [JsonIgnore] GraphCost FixedCost { get; }
         [JsonIgnore] GraphCost VariableCost { get; }
         [JsonIgnore] double TotalCost { get; }
+        [JsonIgnore] double CapacityFactor { get; }
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/NatGasBoiler.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/NatGasBoiler.cs
@@ -31,6 +31,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Gas;
+        public override double CapacityFactor => 1;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
@@ -50,6 +50,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(1313)] public override double F { get; set; } = 1313;
         [DataMember] [DefaultValue(0)] public override double V { get; set; }
         public override double Capacity => CalcCapacity();
+        public override double CapacityFactor => OFF_PV;
 
         private double CalcCapacity()
         {

--- a/DistrictEnergy/Networks/ThermalPlants/SolarThermalCollector.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/SolarThermalCollector.cs
@@ -55,6 +55,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(7191)] public override double F { get; set; } = 7191;
         [DataMember] [DefaultValue(0.00887)] public override double V { get; set; } = 0.00887;
         public override double Capacity => CalcCapacity();
+        public override double CapacityFactor => OFF_SHW;
 
         private double CalcCapacity()
         {

--- a/DistrictEnergy/Networks/ThermalPlants/Storage.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Storage.cs
@@ -31,5 +31,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public GraphCost FixedCost => new FixedCost(this);
         public GraphCost VariableCost => new VariableCost(this, 200);
         public double TotalCost => FixedCost.Cost + VariableCost.Cost;
+        public double CapacityFactor => 1;
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/Storage.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Storage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
 using LiveCharts.Defaults;
@@ -18,7 +19,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public abstract double StartingCapacity { get; }
         public abstract double F { get; set; }
         public abstract double V { get; set; }
-        public double Capacity { get; set; }
+        public abstract double Capacity { get; }
         public abstract string Name { get; set; }
         public Guid Id { get; set; } = Guid.NewGuid();
         public abstract LoadTypes OutputType { get; }

--- a/DistrictEnergy/Networks/ThermalPlants/WindTurbine.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/WindTurbine.cs
@@ -64,6 +64,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(1347)] public override double F { get; set; } = 1347;
         [DataMember] [DefaultValue(0)] public override double V { get; set; }
         public override double Capacity => CalcCapacity();
+        public override double CapacityFactor => OFF_WND;
 
         private double CalcCapacity()
         {

--- a/DistrictEnergy/ViewModels/ElectricGenerationViewModel.cs
+++ b/DistrictEnergy/ViewModels/ElectricGenerationViewModel.cs
@@ -173,7 +173,6 @@ namespace DistrictEnergy.ViewModels
             {
                 DistrictControl.Instance.ListOfPlantSettings.OfType<BatteryBank>().First().AUT_BAT = value;
                 OnPropertyChanged();
-                CalcBatCapacity();
             }
         }
 
@@ -215,23 +214,6 @@ namespace DistrictEnergy.ViewModels
                 DistrictControl.Instance.ListOfPlantSettings.OfType<BatteryBank>().First().V = value;
                 OnPropertyChanged();
             }
-        }
-
-        public double BatCapacity
-        {
-            get { return _windCapacity; }
-            set
-            {
-                DistrictControl.Instance.ListOfPlantSettings.OfType<BatteryBank>().First().Capacity = value;
-                OnPropertyChanged();
-            }
-        }
-
-        private void CalcBatCapacity()
-        {
-            // todo Define a more advanced capacity formulation
-            BatCapacity = DistrictControl.Instance.ListOfDistrictLoads.Where(x => x.LoadType == LoadTypes.Elec).Select(v => v.Input.Average()).Sum() *
-                          DistrictControl.Instance.ListOfPlantSettings.OfType<BatteryBank>().First().AUT_BAT * 24;
         }
 
         #endregion

--- a/DistrictEnergy/ViewModels/HotWaterViewModel.cs
+++ b/DistrictEnergy/ViewModels/HotWaterViewModel.cs
@@ -145,7 +145,6 @@ namespace DistrictEnergy.ViewModels
             {
                 DistrictControl.Instance.ListOfPlantSettings.OfType<HotWaterStorage>().First().AUT_HWT = value;
                 OnPropertyChanged();
-                CalcHwStoCapacityCapacity();
             }
         }
 
@@ -177,23 +176,6 @@ namespace DistrictEnergy.ViewModels
                 DistrictControl.Instance.ListOfPlantSettings.OfType<HotWaterStorage>().First().V = value;
                 OnPropertyChanged();
             }
-        }
-
-        public double HwStoCapacity
-        {
-            get { return _hwStoCapacity; }
-            set
-            {
-                DistrictControl.Instance.ListOfPlantSettings.OfType<HotWaterStorage>().First().Capacity = value;
-                OnPropertyChanged();
-            }
-        }
-
-        private void CalcHwStoCapacityCapacity()
-        {
-            // todo Define a more advanced capacity formulation
-            HwStoCapacity = DistrictControl.Instance.ListOfDistrictLoads.Where(x=>x.LoadType == LoadTypes.Heating).Select(v=>v.Input.Average()).Sum() *
-                            DistrictControl.Instance.ListOfPlantSettings.OfType<HotWaterStorage>().First().AUT_HWT * 24;
         }
 
         #endregion

--- a/DistrictEnergy/ViewModels/HotWaterViewModel.cs
+++ b/DistrictEnergy/ViewModels/HotWaterViewModel.cs
@@ -60,7 +60,6 @@ namespace DistrictEnergy.ViewModels
             {
                 DistrictControl.Instance.ListOfPlantSettings.OfType<ElectricHeatPump>().First().OFF_EHP = value / 100;
                 OnPropertyChanged();
-                CalcHpCapacity();
             }
         }
 
@@ -116,22 +115,6 @@ namespace DistrictEnergy.ViewModels
                 DistrictControl.Instance.ListOfPlantSettings.OfType<ElectricHeatPump>().First().V = value;
                 OnPropertyChanged();
             }
-        }
-
-        public double HpCapacity
-        {
-            get { return _hpCapacity; }
-            set
-            {
-                _hpCapacity = value;
-                OnPropertyChanged();
-            }
-        }
-
-        private void CalcHpCapacity()
-        {
-            HpCapacity = DistrictControl.Instance.ListOfPlantSettings.OfType<ElectricHeatPump>().First().OFF_EHP *
-                         DistrictControl.Instance.ListOfDistrictLoads.Where(x => x.LoadType == LoadTypes.Heating).Select(v => v.Input.Max()).Sum();
         }
 
         #endregion

--- a/DistrictEnergy/Views/PlantSettings/ChilledWaterView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/ChilledWaterView.xaml
@@ -72,7 +72,7 @@
                                     </Grid.ColumnDefinitions>
                                     <Slider VerticalAlignment="Center" Maximum="100" x:Name="SliderA"
                                             Value="{Binding OFF_ABS, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                            ToolTip="Capacity as percent of peak cooling load"
+                                            ToolTip="Capacity factor as ratio of the total cooling energy supplied by the energy hub"
                                             IsSnapToTickEnabled="True" Focusable="False" />
 
                                     <StackPanel Orientation="Horizontal" Grid.Column="1"
@@ -142,7 +142,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    <TextBlock Style="{DynamicResource MaterialDesignSubtitle1TextBlock}" Grid.Row="0">Electric Chiller</TextBlock>
+                    <TextBlock Style="{DynamicResource MaterialDesignSubtitle1TextBlock}" Grid.Row="0" ToolTip="Always Available">Electric Chiller</TextBlock>
                     <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Top" Width="Auto"
                                 Grid.Row="1">
                         <Expander>

--- a/DistrictEnergy/Views/PlantSettings/CombinedHeatAndPowerView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/CombinedHeatAndPowerView.xaml
@@ -85,7 +85,7 @@
                                     </Grid.ColumnDefinitions>
                                     <Slider VerticalAlignment="Center" Margin="0" Maximum="100"
                                             Value="{Binding OFF_CHP, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                            ToolTip="Ratio of electricity delivered by generator to total demand at peak conditions"
+                                            ToolTip="Capacity factor as ratio of the total heating OR electricity energy supplied by the energy hub. See Tracking Mode."
                                             IsSnapToTickEnabled="True" Focusable="False" />
                                     <StackPanel Orientation="Horizontal" Grid.Column="1"
 

--- a/DistrictEnergy/Views/PlantSettings/ElectricGenerationView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/ElectricGenerationView.xaml
@@ -95,7 +95,7 @@
                                     </Grid.ColumnDefinitions>
                                     <Slider VerticalAlignment="Center" Maximum="100"
                                             Value="{Binding OFF_PV, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                            ToolTip="Ratio of electricity delivered by PV Array to total annual electricity requirement"
+                                            ToolTip="Capacity factor as ratio of the total electricity energy supplied by the energy hub"
                                             IsSnapToTickEnabled="True" Focusable="False" />
                                     <StackPanel Orientation="Horizontal" Grid.Column="1"
                                                 Grid.ColumnSpan="2"
@@ -209,7 +209,7 @@
                                     </Grid.ColumnDefinitions>
                                     <Slider VerticalAlignment="Center" Margin="0" Maximum="100"
                                             Value="{Binding OFF_WND, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                            ToolTip="Ratio of electricity delivered by wind turbines to total annual electricity requirement"
+                                            ToolTip="Capacity factor as ratio of the total electricity energy supplied by the energy hub"
                                             IsSnapToTickEnabled="True" Focusable="False" />
                                     <StackPanel Orientation="Horizontal" Grid.Column="1"
                                                 Grid.ColumnSpan="2"
@@ -458,7 +458,7 @@
                     </StackPanel>
                 </Grid>
                 <StackPanel x:Name="stackCustomCW">
-                    <Button Name="btnAddCustomElectricityModule" Margin="0,20,0,0" Click="btnAddCustomElectricityModule_Click">Add Custom Chilled Water Supply Module</Button>
+                    <Button Name="btnAddCustomElectricityModule" Margin="0,20,0,0" Click="btnAddCustomElectricityModule_Click">Add Custom Electricity Supply Module</Button>
                 </StackPanel>
 
             </StackPanel>

--- a/DistrictEnergy/Views/PlantSettings/HotWaterView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/HotWaterView.xaml
@@ -87,7 +87,7 @@
                                     </Grid.ColumnDefinitions>
                                     <Slider VerticalAlignment="Center" Margin="0" Maximum="100"
                                             Value="{Binding OFF_EHP, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                            ToolTip="Ratio of heating delivered by heat pumps to total load at peak conditions"
+                                            ToolTip="Capacity factor as ratio of the total heating energy supplied by the energy hub"
                                             IsSnapToTickEnabled="True" Focusable="False" />
                                     <StackPanel Orientation="Horizontal" Grid.Column="1"
                                                 Grid.ColumnSpan="2"
@@ -189,7 +189,7 @@
                                     </Grid.ColumnDefinitions>
                                     <Slider VerticalAlignment="Center" Margin="0" Maximum="100"
                                             Value="{Binding OFF_SHW, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                            ToolTip="Ratio of heating delivered by solar collectors to total annual heating requirement"
+                                            ToolTip="Capacity factor as ratio of the total heating energy supplied by the energy hub"
                                             IsSnapToTickEnabled="True" Focusable="False" />
                                     <StackPanel Orientation="Horizontal" Grid.Column="1"
                                                 Grid.ColumnSpan="2"


### PR DESCRIPTION
The capacity sliders are now acting on the ratio of the total energy supplied by the energy hub met by each energy supply modules.

In the model, the capacity is set as an inequality constraint instead of a bounded value.