### PR TITLE
Tracking Mode for CHP plant is considered in linear problem

### DIFF
--- a/DistrictEnergy/DistrictControl.xaml.cs
+++ b/DistrictEnergy/DistrictControl.xaml.cs
@@ -204,7 +204,7 @@ namespace DistrictEnergy
                 {
                     ChilledWaterViewModel.Instance.OFF_ABS = 100;
                     CombinedHeatAndPowerViewModel.Instance.OFF_CHP = 100;
-                    CombinedHeatAndPowerViewModel.Instance.TMOD_CHP = TrakingModeEnum.Electrical;
+                    CombinedHeatAndPowerViewModel.Instance.TMOD_CHP = LoadTypes.Elec;
                     ElectricGenerationViewModel.Instance.OFF_PV = 0;
                     HotWaterViewModel.Instance.OFF_EHP = 0;
                     HotWaterViewModel.Instance.OFF_SHW = 0;

--- a/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
@@ -25,8 +25,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         ///     Tracking Mode
         /// </summary>
         [DataMember]
-        [DefaultValue(TrakingModeEnum.Thermal)]
-        public TrakingModeEnum TMOD_CHP { get; set; } = TrakingModeEnum.Thermal;
+        [DefaultValue(LoadTypes.Heating)]
+        public LoadTypes TMOD_CHP { get; set; } = LoadTypes.Heating;
 
         /// <summary>
         ///     Capacity as percent of peak electric load (%)
@@ -70,10 +70,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
             if (DistrictControl.Instance is null) return 0;
             switch (TMOD_CHP)
             {
-                case TrakingModeEnum.Electrical:
+                case LoadTypes.Elec:
                     return OFF_CHP * DistrictControl.Instance.ListOfDistrictLoads
                         .Where(x => x.LoadType == LoadTypes.Elec).Select(v => v.Input.Max()).Sum();
-                case TrakingModeEnum.Thermal:
+                case LoadTypes.Heating:
                     return OFF_CHP * DistrictControl.Instance.ListOfDistrictLoads
                         .Where(x => x.LoadType == LoadTypes.Heating).Select(v => v.Input.Max()).Sum();
             }
@@ -86,7 +86,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override string Name { get; set; } = "Combined Heat&Power";
 
         public override Guid Id { get; set; } = Guid.NewGuid();
-        public override LoadTypes OutputType => LoadTypes.Elec;
+        public override LoadTypes OutputType => TMOD_CHP;
         public override LoadTypes InputType => LoadTypes.Gas;
         public override double CapacityFactor => OFF_CHP;
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
@@ -94,12 +94,5 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];
         public override SolidColorBrush Fill { get; set; } = new SolidColorBrush(Color.FromRgb(247, 96, 21));
-    }
-
-    [DataContract(Name = "TMOD_CHP")]
-    public enum TrakingModeEnum
-    {
-        [EnumMember] Thermal,
-        [EnumMember] Electrical
     }
 }

--- a/DistrictEnergy/ViewModels/CombinedHeatAndPowerViewModel.cs
+++ b/DistrictEnergy/ViewModels/CombinedHeatAndPowerViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using DistrictEnergy.Helpers;
 using DistrictEnergy.Networks.ThermalPlants;
 
 namespace DistrictEnergy.ViewModels
@@ -16,10 +17,10 @@ namespace DistrictEnergy.ViewModels
 
         public new static CombinedHeatAndPowerViewModel Instance { get; set; }
 
-        public IList<TrakingModeEnum> PosibleTrackingModes =>
-            Enum.GetValues(typeof(TrakingModeEnum)).Cast<TrakingModeEnum>().ToList();
+        public IList<LoadTypes> PosibleTrackingModes =>
+            new List<LoadTypes>() {LoadTypes.Elec, LoadTypes.Heating};
 
-        public TrakingModeEnum TMOD_CHP
+        public LoadTypes TMOD_CHP
         {
             get => DistrictControl.Instance.ListOfPlantSettings.OfType<CombinedHeatNPower>().First().TMOD_CHP;
             set


### PR DESCRIPTION
Setting the tracking mode will change the capacity upper bound of the CHP plant. For example, if tracking heating and capacity ratio is set to 90%, the CHP plant will try to cover 90% of the heating demand of the Energy Hub. Similarly, if tracking is set to elec, the CHP plant will try to cover 90% of the electricity demand of the Energy Hub.