### PR TITLE
Fixes costs accounting & display in views

### DIFF
--- a/DistrictEnergy/DHRunLPModel.cs
+++ b/DistrictEnergy/DHRunLPModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using DistrictEnergy.Helpers;
@@ -8,6 +8,7 @@ using DistrictEnergy.Networks.ThermalPlants;
 using Google.OrTools.LinearSolver;
 using Rhino;
 using Rhino.Commands;
+using Umi.RhinoServices.Context;
 
 namespace DistrictEnergy
 {
@@ -279,7 +280,7 @@ namespace DistrictEnergy
 
             foreach (var variable in E)
             {
-                objective.SetCoefficient(variable.Value, 1000000);
+                objective.SetCoefficient(variable.Value, UmiContext.Current.ProjectSettings.ElectricityDollars);
             }
 
             objective.SetMinimization();

--- a/DistrictEnergy/DHRunLPModel.cs
+++ b/DistrictEnergy/DHRunLPModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DistrictEnergy.Helpers;
@@ -210,8 +210,7 @@ namespace DistrictEnergy
                                    .Select(x => x.Value).ToArray().Sum() -
                                Qout.Where(k => k.Key.Item2.OutputType == loadType && k.Key.Item1 == i)
                                    .Select(x => x.Value).ToArray().Sum() +
-                               Load.Where(x => x.Key.Item2 == loadType && x.Key.Item1 == i).Select(o => o.Value).Sum() +
-                               E[(i, loadType)])
+                               Load.Where(x => x.Key.Item2 == loadType && x.Key.Item1 == i).Select(o => o.Value).Sum())
                 );
             }
 

--- a/DistrictEnergy/DHRunLPModel.cs
+++ b/DistrictEnergy/DHRunLPModel.cs
@@ -264,7 +264,7 @@ namespace DistrictEnergy
                 for (int t = dt; t < timeSteps * dt; t += dt)
                 {
                     objective.SetCoefficient(P[(t, supplymodule)],
-                        supplymodule.F * DistrictEnergy.Settings.AnnuityFactor + supplymodule.V * dt);
+                        supplymodule.F * DistrictEnergy.Settings.AnnuityFactor / dt + supplymodule.V);
                 }
             }
 
@@ -273,7 +273,7 @@ namespace DistrictEnergy
                 for (int t = dt; t < timeSteps * dt; t += dt)
                 {
                     objective.SetCoefficient(S[(t, storage)],
-                        storage.F * DistrictEnergy.Settings.AnnuityFactor + storage.V * dt);
+                        storage.F * DistrictEnergy.Settings.AnnuityFactor / dt + storage.V);
                 }
             }
 

--- a/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Media;

--- a/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Media;
@@ -42,7 +42,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
             Fill = new SolidColorBrush(Color.FromArgb(alpha, color.R, color.G, color.B));
             Name = plant.Name + " Fixed Cost";
             if (plant.Output != null)
-                Cost = plant.Output.Max() * DistrictControl.PlanningSettings.AnnuityFactor * plant.F;
+                Cost = plant.Output.Max() * DistrictControl.PlanningSettings.AnnuityFactor * plant.F /
+                       (8760 / DistrictControl.PlanningSettings.TimeSteps);
         }
     }
 


### PR DESCRIPTION
Upper cost boundary now excludes the export energy because it did not make sense to include it.

Costs are adjusted with period length