### PR TITLE
Fixed: Some user-defined parameters (eg. COPs) would not be taken into account

### DIFF
--- a/DistrictEnergy/Networks/ThermalPlants/AbsorptionChiller.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/AbsorptionChiller.cs
@@ -13,12 +13,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public AbsorptionChiller()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Cooling, CCOP_ABS},
-                {LoadTypes.Heating, -1}
-
-            };
         }
 
         /// <summary>
@@ -64,7 +58,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType { get; } = LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Heating;
         public override double CapacityFactor => OFF_ABS;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Cooling, CCOP_ABS},
+            {LoadTypes.Heating, -1}
+
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];

--- a/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
@@ -13,12 +13,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public CombinedHeatNPower()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Elec, EFF_CHP},
-                {LoadTypes.Heating, HREC_CHP},
-                {LoadTypes.Gas, -1}
-            };
         }
 
         /// <summary>
@@ -89,7 +83,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => TMOD_CHP;
         public override LoadTypes InputType => LoadTypes.Gas;
         public override double CapacityFactor => OFF_CHP;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Elec, EFF_CHP},
+            {LoadTypes.Heating, HREC_CHP},
+            {LoadTypes.Gas, -1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];

--- a/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
@@ -10,10 +10,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public CustomCoolingSupplyModule()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Cooling, 1}
-            };
         }
 
         public double ComputeHeatBalance(double demand, int i)
@@ -30,7 +26,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Custom;
         public override double CapacityFactor => 1;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Cooling, 1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double F { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
@@ -10,16 +10,15 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         public CustomElectricitySupplyModule()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Elec, 1}
-            };
         }
 
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.Custom;
         public override double CapacityFactor => 1;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Elec, 1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double F { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
@@ -106,7 +106,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override double CapacityFactor { get; }
 
         public Color Color { get; set; } = Color.FromRgb(200, 1, 0);
-        public abstract override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public abstract override Dictionary<LoadTypes, double> ConversionMatrix { get; }
         public abstract override double Efficiency { get; }
 
         public double ComputeHeatBalance(double demand, double chiller, double solar, int i)

--- a/DistrictEnergy/Networks/ThermalPlants/CustomHeatingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomHeatingSupplyModule.cs
@@ -8,16 +8,15 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public CustomHeatingSupplyModule()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Heating, 1}
-            };
         }
 
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Custom;
         public override double CapacityFactor => 1;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Heating, 1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double F { get; set; }

--- a/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
@@ -17,7 +17,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public abstract string Name { get; set; }
         public abstract Guid Id { get; set; }
         public abstract LoadTypes OutputType { get; }
-        public abstract Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public abstract Dictionary<LoadTypes, double> ConversionMatrix { get; }
         public abstract List<DateTimePoint> Input { get; set; }
         public abstract List<DateTimePoint> Output { get; set; }
         public abstract double Efficiency { get; }

--- a/DistrictEnergy/Networks/ThermalPlants/ElectricChiller.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ElectricChiller.cs
@@ -12,11 +12,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public ElectricChiller()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Cooling, CCOP_ECH},
-                {LoadTypes.Elec, -1}
-            };
         }
 
         /// <summary>
@@ -34,7 +29,11 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Elec;
         public override double CapacityFactor => 1;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Cooling, CCOP_ECH},
+            {LoadTypes.Elec, -1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];

--- a/DistrictEnergy/Networks/ThermalPlants/ElectricHeatPump.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ElectricHeatPump.cs
@@ -13,12 +13,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public ElectricHeatPump()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Heating, HCOP_EHP},
-                {LoadTypes.Cooling, (1-1/HCOP_EHP)}, // TODO Add Switch for Use Evaporator or Not
-                {LoadTypes.Elec, -1}
-            };
         }
 
         /// <summary>
@@ -59,7 +53,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Elec;
         public override double CapacityFactor => OFF_EHP;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Heating, HCOP_EHP },
+            {LoadTypes.Cooling, UseEhpEvap == 0? 0 : (1-1/HCOP_EHP)},
+            {LoadTypes.Elec, -1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];

--- a/DistrictEnergy/Networks/ThermalPlants/GridElectricity.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/GridElectricity.cs
@@ -13,10 +13,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public GridElectricity()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Elec, 1}
-            };
         }
 
         [DataMember] [DefaultValue(0)] public override double F { get; set; } = 0;
@@ -39,7 +35,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.GridElec;
         public override double CapacityFactor => 1;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Elec, 1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];

--- a/DistrictEnergy/Networks/ThermalPlants/GridGas.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/GridGas.cs
@@ -13,10 +13,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public GridGas()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Gas, 1}
-            };
         }
         [DataMember] [DefaultValue(0)] public override double F { get; set; } = 0;
 
@@ -37,7 +33,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Gas;
         public override LoadTypes InputType => LoadTypes.GridGas;
         public override double CapacityFactor => 1;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Gas, 1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];

--- a/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
@@ -44,7 +44,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         Guid Id { get; set; }
 
         LoadTypes OutputType { get; }
-        [JsonIgnore] Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        [JsonIgnore] Dictionary<LoadTypes, double> ConversionMatrix { get; }
 
         /// <summary>
         /// Input Energy to the Supply Module per period

--- a/DistrictEnergy/Networks/ThermalPlants/NatGasBoiler.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/NatGasBoiler.cs
@@ -12,11 +12,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public NatGasBoiler()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Heating, EFF_NGB},
-                {LoadTypes.Gas, -1}
-            };
         }
         /// <summary>
         ///     Heating efficiency (%)
@@ -32,7 +27,11 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Gas;
         public override double CapacityFactor => 1;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Heating, EFF_NGB},
+            {LoadTypes.Gas, -1}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];

--- a/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
@@ -13,10 +13,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public PhotovoltaicArray()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Elec, EFF_PV * UTIL_PV * (1 - LOSS_PV)}
-            };
         }
 
         /// <summary>
@@ -62,7 +58,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.SolarRadiation;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Elec, EFF_PV * UTIL_PV * (1 - LOSS_PV)}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];

--- a/DistrictEnergy/Networks/ThermalPlants/SolarThermalCollector.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/SolarThermalCollector.cs
@@ -14,10 +14,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
     {
         public SolarThermalCollector()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Heating, EFF_SHW * (1 - LOSS_SHW) * UTIL_SHW}
-            };
         }
 
         /// <summary>
@@ -72,7 +68,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.SolarRadiation;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Heating, EFF_SHW * (1 - LOSS_SHW) * UTIL_SHW}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[LoadTypes.Heating];

--- a/DistrictEnergy/Networks/ThermalPlants/WindTurbine.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/WindTurbine.cs
@@ -14,10 +14,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         public WindTurbine()
         {
-            ConversionMatrix = new Dictionary<LoadTypes, double>()
-            {
-                {LoadTypes.Elec, (1-LOSS_WND)}
-            };
         }
         /// <summary>
         ///     Target offset as percent of annual energy (%)
@@ -81,7 +77,10 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.Wind;
-        public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
+        public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
+        {
+            {LoadTypes.Elec, (1-LOSS_WND)}
+        };
         public override List<DateTimePoint> Input { get; set; }
         public override List<DateTimePoint> Output { get; set; }
         public override double Efficiency => ConversionMatrix[OutputType];


### PR DESCRIPTION
Fixes an issue where the conversionMatrix would not take the latest user-defined parameters. It would only consider the default values.