### PR TITLE
New: Ability to force the capacity factor of energy supply modules

### DIFF
--- a/DistrictEnergy/DHRunLPModel.cs
+++ b/DistrictEnergy/DHRunLPModel.cs
@@ -222,25 +222,26 @@ namespace DistrictEnergy
                 x.Key.Item2.OutputType == LoadTypes.Elec || x.Key.Item2.OutputType == LoadTypes.Heating ||
                 x.Key.Item2.OutputType == LoadTypes.Cooling))
             {
-                var loadType = inputFlow.Key.Item2.OutputType;
                 var i = inputFlow.Key.Item1;
-                LpModel.Add(inputFlow.Value * inputFlow.Key.Item2.ConversionMatrix[loadType] <= inputFlow.Key.Item2.CapacityFactor * TotalDemand(loadType, i)
-                );
+                var plant = inputFlow.Key.Item2;
+                var loadType = plant.OutputType;
+                LpModel.Add(inputFlow.Value * plant.ConversionMatrix[loadType] <= plant.CapacityFactor * TotalDemand(loadType, i));
             }
 
-            foreach (var supplyModule in DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>())
+            // Forced Capacity Constraints
+            foreach (var plant in DistrictControl.Instance.ListOfPlantSettings.OfType<Dispatchable>())
             {
-                foreach (var inputFlow in P.Where(x=>x.Key.Item2==supplyModule))
+                if (plant.IsForced)
                 {
-                    LoadTypes loadType = supplyModule.OutputType;
-                    var i = inputFlow.Key.Item1;
-                    LpModel.Add(inputFlow.Value * inputFlow.Key.Item2.ConversionMatrix[loadType] == supplyModule.CapacityFactor * supplyModule.Capacity
-                    );
+                    for (int t = 0; t < timeSteps * dt; t += dt)
+                    {
+                        var loadType = plant.OutputType;
+                        LpModel.Add(P[(t, plant)] * plant.ConversionMatrix[loadType] == plant.CapacityFactor * TotalDemand(loadType, t));
+                    }
                 }
-                
             }
 
-            // Solar & Wind Constraints
+            // Solar Constraints
             foreach (var solarSupply in DistrictControl.Instance.ListOfPlantSettings.OfType<ISolar>())
             {
                 for (int t = 0; t < timeSteps * dt; t += dt)
@@ -249,7 +250,7 @@ namespace DistrictEnergy
                         solarSupply.AvailableArea);
                 }
             }
-            // Solar & Wind Constraints
+            // Wind Constraints
             foreach (var windTurbine in DistrictControl.Instance.ListOfPlantSettings.OfType<IWind>())
             {
                 for (int t = 0; t < timeSteps * dt; t += dt)

--- a/DistrictEnergy/DHRunLPModel.cs
+++ b/DistrictEnergy/DHRunLPModel.cs
@@ -228,6 +228,18 @@ namespace DistrictEnergy
                 );
             }
 
+            foreach (var supplyModule in DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>())
+            {
+                foreach (var inputFlow in P.Where(x=>x.Key.Item2==supplyModule))
+                {
+                    LoadTypes loadType = supplyModule.OutputType;
+                    var i = inputFlow.Key.Item1;
+                    LpModel.Add(inputFlow.Value * inputFlow.Key.Item2.ConversionMatrix[loadType] == supplyModule.CapacityFactor * supplyModule.Capacity
+                    );
+                }
+                
+            }
+
             // Solar & Wind Constraints
             foreach (var solarSupply in DistrictControl.Instance.ListOfPlantSettings.OfType<ISolar>())
             {

--- a/DistrictEnergy/Networks/ThermalPlants/AbsorptionChiller.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/AbsorptionChiller.cs
@@ -58,6 +58,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType { get; } = LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Heating;
         public override double CapacityFactor => OFF_ABS;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Cooling, CCOP_ABS},

--- a/DistrictEnergy/Networks/ThermalPlants/AbsorptionChiller.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/AbsorptionChiller.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
+using DistrictEnergy.ViewModels;
 using LiveCharts.Defaults;
 
 namespace DistrictEnergy.Networks.ThermalPlants
@@ -57,7 +58,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType { get; } = LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Heating;
-        public override double CapacityFactor => OFF_ABS;
+        public override double CapacityFactor
+        {
+            get => OFF_ABS;
+            set => ChilledWaterViewModel.Instance.OFF_ABS = value * 100;
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/BatteryBank.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/BatteryBank.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
 using LiveCharts.Defaults;
+using Newtonsoft.Json;
 
 namespace DistrictEnergy.Networks.ThermalPlants
 {
@@ -59,12 +60,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public double Efficiency => ConversionMatrix[OutputType];
         public override SolidColorBrush Fill { get; set; } = new SolidColorBrush(Color.FromRgb(231, 71, 126));
-        public override double ChargingEfficiency => 1 - LOSS_BAT;
-        public override double DischargingEfficiency => 1 - LOSS_BAT;
-        public override double MaxChargingRate => Capacity > 0 ? Capacity / AUT_BAT : 0;
-        public override double MaxDischargingRate => Capacity > 0 ? Capacity / AUT_BAT : 0;
-        public override double StartingCapacity => Capacity * BAT_START;
-        public override double Capacity => CalcCapacity();
+        [JsonIgnore] public override double ChargingEfficiency => 1 - LOSS_BAT;
+        [JsonIgnore] public override double DischargingEfficiency => 1 - LOSS_BAT;
+        [JsonIgnore] public override double MaxChargingRate => Capacity > 0 ? Capacity / AUT_BAT : 0;
+        [JsonIgnore] public override double MaxDischargingRate => Capacity > 0 ? Capacity / AUT_BAT : 0;
+        [JsonIgnore] public override double StartingCapacity => Capacity * BAT_START;
+        [JsonIgnore] public override double Capacity => CalcCapacity();
         private double CalcCapacity()
         {
             return DistrictControl.Instance.ListOfDistrictLoads.Where(x => x.LoadType == LoadTypes.Elec).Select(v => v.Input.Average()).Sum() * AUT_BAT * 24;

--- a/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
+using DistrictEnergy.ViewModels;
 using LiveCharts.Defaults;
 
 namespace DistrictEnergy.Networks.ThermalPlants
@@ -82,7 +83,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => TMOD_CHP;
         public override LoadTypes InputType => LoadTypes.Gas;
-        public override double CapacityFactor => OFF_CHP;
+        public override double CapacityFactor
+        {
+            get => OFF_CHP;
+            set => CombinedHeatAndPowerViewModel.Instance.OFF_CHP = value * 100;
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CombinedHeatNPower.cs
@@ -83,6 +83,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => TMOD_CHP;
         public override LoadTypes InputType => LoadTypes.Gas;
         public override double CapacityFactor => OFF_CHP;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Elec, EFF_CHP},

--- a/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
@@ -24,8 +24,9 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         public double[] Used = new double[8760];
         public override LoadTypes OutputType => LoadTypes.Cooling;
+        public override double OFF_Custom { get; set; } = 1;
         public override LoadTypes InputType => LoadTypes.Custom;
-        public override double CapacityFactor => 1;
+        public override double CapacityFactor => OFF_Custom;
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Cooling, 1}

--- a/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
@@ -27,6 +27,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override double OFF_Custom { get; set; } = 1;
         public override LoadTypes InputType => LoadTypes.Custom;
         public override double CapacityFactor => OFF_Custom;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Cooling, 1}

--- a/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomCoolingSupplyModule.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DistrictEnergy.Helpers;
+using DistrictEnergy.ViewModels;
 using LiveCharts.Defaults;
 
 namespace DistrictEnergy.Networks.ThermalPlants
@@ -26,7 +27,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Cooling;
         public override double OFF_Custom { get; set; } = 1;
         public override LoadTypes InputType => LoadTypes.Custom;
-        public override double CapacityFactor => OFF_Custom;
+        public override double CapacityFactor
+        {
+            get => OFF_Custom;
+            set { }
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
@@ -13,8 +13,9 @@ namespace DistrictEnergy.Networks.ThermalPlants
         }
 
         public override LoadTypes OutputType => LoadTypes.Elec;
+        public override double OFF_Custom { get; set; } = 1;
         public override LoadTypes InputType => LoadTypes.Custom;
-        public override double CapacityFactor => 1;
+        public override double CapacityFactor => OFF_Custom;
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Elec, 1}

--- a/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
@@ -15,7 +15,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override double OFF_Custom { get; set; } = 1;
         public override LoadTypes InputType => LoadTypes.Custom;
-        public override double CapacityFactor => OFF_Custom;
+        public override double CapacityFactor
+        {
+            get => OFF_Custom;
+            set => OFF_Custom = value;
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomElectricitySupplyModule.cs
@@ -16,6 +16,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override double OFF_Custom { get; set; } = 1;
         public override LoadTypes InputType => LoadTypes.Custom;
         public override double CapacityFactor => OFF_Custom;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Elec, 1}

--- a/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
@@ -34,6 +34,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         public abstract override LoadTypes OutputType { get; }
 
+        public abstract double OFF_Custom { get; set; }
+
         public abstract override double F { get; set; }
         public abstract override double V { get; set; }
         public abstract override double Capacity { get; }

--- a/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
@@ -110,6 +110,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public Color Color { get; set; } = Color.FromRgb(200, 1, 0);
         public abstract override Dictionary<LoadTypes, double> ConversionMatrix { get; }
         public abstract override double Efficiency { get; }
+        public abstract override bool IsForced { get; set; }
 
         public double ComputeHeatBalance(double demand, double chiller, double solar, int i)
         {

--- a/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomEnergySupplyModule.cs
@@ -105,7 +105,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
             set => throw new NotImplementedException();
         }
 
-        public override double CapacityFactor { get; }
+        public override double CapacityFactor { get; set; }
 
         public Color Color { get; set; } = Color.FromRgb(200, 1, 0);
         public abstract override Dictionary<LoadTypes, double> ConversionMatrix { get; }

--- a/DistrictEnergy/Networks/ThermalPlants/CustomHeatingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomHeatingSupplyModule.cs
@@ -14,6 +14,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override double OFF_Custom { get; set; } = 1;
         public override LoadTypes InputType => LoadTypes.Custom;
         public override double CapacityFactor => OFF_Custom;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Heating, 1}

--- a/DistrictEnergy/Networks/ThermalPlants/CustomHeatingSupplyModule.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/CustomHeatingSupplyModule.cs
@@ -11,8 +11,9 @@ namespace DistrictEnergy.Networks.ThermalPlants
         }
 
         public override LoadTypes OutputType => LoadTypes.Heating;
+        public override double OFF_Custom { get; set; } = 1;
         public override LoadTypes InputType => LoadTypes.Custom;
-        public override double CapacityFactor => 1;
+        public override double CapacityFactor => OFF_Custom;
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Heating, 1}

--- a/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
@@ -27,6 +27,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public GraphCost VariableCost => new VariableCost(this, 200);
         public double TotalCost => FixedCost.Cost + VariableCost.Cost;
         public abstract double CapacityFactor { get; }
+        public abstract bool IsForced { get; set; }
     }
 
     public class FixedCost : GraphCost

--- a/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Dispatchable.cs
@@ -26,7 +26,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public GraphCost FixedCost => new FixedCost(this);
         public GraphCost VariableCost => new VariableCost(this, 200);
         public double TotalCost => FixedCost.Cost + VariableCost.Cost;
-        public abstract double CapacityFactor { get; }
+        public abstract double CapacityFactor { get; set; }
         public abstract bool IsForced { get; set; }
     }
 

--- a/DistrictEnergy/Networks/ThermalPlants/ElectricChiller.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ElectricChiller.cs
@@ -29,6 +29,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Elec;
         public override double CapacityFactor => 1;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Cooling, CCOP_ECH},

--- a/DistrictEnergy/Networks/ThermalPlants/ElectricChiller.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ElectricChiller.cs
@@ -28,7 +28,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; }
         public override LoadTypes OutputType => LoadTypes.Cooling;
         public override LoadTypes InputType => LoadTypes.Elec;
-        public override double CapacityFactor => 1;
+        public override double CapacityFactor
+        {
+            get => 1;
+            set {}
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/ElectricHeatPump.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ElectricHeatPump.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
+using DistrictEnergy.ViewModels;
 using LiveCharts.Defaults;
 
 namespace DistrictEnergy.Networks.ThermalPlants
@@ -52,7 +53,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Elec;
-        public override double CapacityFactor => OFF_EHP;
+        public override double CapacityFactor
+        {
+            get => OFF_EHP;
+            set => HotWaterViewModel.Instance.OFF_EHP = value * 100;
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/ElectricHeatPump.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ElectricHeatPump.cs
@@ -53,6 +53,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Elec;
         public override double CapacityFactor => OFF_EHP;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Heating, HCOP_EHP },

--- a/DistrictEnergy/Networks/ThermalPlants/GridElectricity.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/GridElectricity.cs
@@ -34,7 +34,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.GridElec;
-        public override double CapacityFactor => 1;
+        public override double CapacityFactor
+        {
+            get => 1;
+            set { }
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/GridElectricity.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/GridElectricity.cs
@@ -35,6 +35,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Elec;
         public override LoadTypes InputType => LoadTypes.GridElec;
         public override double CapacityFactor => 1;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Elec, 1}

--- a/DistrictEnergy/Networks/ThermalPlants/GridGas.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/GridGas.cs
@@ -32,7 +32,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Gas;
         public override LoadTypes InputType => LoadTypes.GridGas;
-        public override double CapacityFactor => 1;
+        public override double CapacityFactor
+        {
+            get => 1;
+            set { }
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/GridGas.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/GridGas.cs
@@ -33,6 +33,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Gas;
         public override LoadTypes InputType => LoadTypes.GridGas;
         public override double CapacityFactor => 1;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Gas, 1}

--- a/DistrictEnergy/Networks/ThermalPlants/HotWaterStorage.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/HotWaterStorage.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
 using LiveCharts.Defaults;
+using Newtonsoft.Json;
 
 namespace DistrictEnergy.Networks.ThermalPlants
 {
@@ -51,12 +52,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Dictionary<LoadTypes, double> ConversionMatrix { get; set; }
         public double Efficiency => ConversionMatrix[OutputType];
         public override SolidColorBrush Fill { get; set; } = new SolidColorBrush(Color.FromRgb(253, 199, 204));
-        public override double ChargingEfficiency => 1 - LOSS_HWT;
-        public override double DischargingEfficiency => 1 - LOSS_HWT;
-        public override double MaxChargingRate => Capacity > 0 ? Capacity / AUT_HWT : 0;
-        public override double MaxDischargingRate => Capacity > 0 ? Capacity / AUT_HWT : 0;
-        public override double StartingCapacity => Capacity * TANK_START;
-        public override double Capacity => CalcCapacity();
+        [JsonIgnore] public override double ChargingEfficiency => 1 - LOSS_HWT;
+        [JsonIgnore] public override double DischargingEfficiency => 1 - LOSS_HWT;
+        [JsonIgnore] public override double MaxChargingRate => Capacity > 0 ? Capacity / AUT_HWT : 0;
+        [JsonIgnore] public override double MaxDischargingRate => Capacity > 0 ? Capacity / AUT_HWT : 0;
+        [JsonIgnore] public override double StartingCapacity => Capacity * TANK_START;
+        [JsonIgnore] public override double Capacity => CalcCapacity();
         private double CalcCapacity()
         {
             return DistrictControl.Instance.ListOfDistrictLoads.Where(x => x.LoadType == LoadTypes.Heating).Select(v => v.Input.Average()).Sum() * AUT_HWT * 24;

--- a/DistrictEnergy/Networks/ThermalPlants/ISolar.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/ISolar.cs
@@ -7,7 +7,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
     /// </summary>
     internal interface ISolar : IThermalPlantSettings
     {
-        double AvailableArea { get; }
+        [JsonIgnore] double AvailableArea { get; }
         [JsonIgnore] double[] SolarAvailableInput { get; }
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
@@ -68,7 +68,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [JsonIgnore] GraphCost FixedCost { get; }
         [JsonIgnore] GraphCost VariableCost { get; }
         [JsonIgnore] double TotalCost { get; }
-        [JsonIgnore] double CapacityFactor { get; }
+        [JsonIgnore] double CapacityFactor { get; set; }
         bool IsForced { get; set; }
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
@@ -69,5 +69,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [JsonIgnore] GraphCost VariableCost { get; }
         [JsonIgnore] double TotalCost { get; }
         [JsonIgnore] double CapacityFactor { get; }
+        bool IsForced { get; set; }
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/IThermalPlantSettings.cs
@@ -30,7 +30,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         /// </summary>
         [DataMember]
         [DefaultValue(double.PositiveInfinity)]
-        double Capacity { get; }
+        [JsonIgnore] double Capacity { get; }
 
         /// <summary>
         /// Name of the Supply Module

--- a/DistrictEnergy/Networks/ThermalPlants/NatGasBoiler.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/NatGasBoiler.cs
@@ -27,6 +27,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Gas;
         public override double CapacityFactor => 1;
+        public override bool IsForced { get; set; }
+
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()
         {
             {LoadTypes.Heating, EFF_NGB},

--- a/DistrictEnergy/Networks/ThermalPlants/NatGasBoiler.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/NatGasBoiler.cs
@@ -26,7 +26,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public override Guid Id { get; set; } = Guid.NewGuid();
         public override LoadTypes OutputType => LoadTypes.Heating;
         public override LoadTypes InputType => LoadTypes.Gas;
-        public override double CapacityFactor => 1;
+        public override double CapacityFactor
+        {
+            get => 1;
+            set { }
+        }
+
         public override bool IsForced { get; set; }
 
         public override Dictionary<LoadTypes, double> ConversionMatrix => new Dictionary<LoadTypes, double>()

--- a/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -45,8 +45,8 @@ namespace DistrictEnergy.Networks.ThermalPlants
 
         [DataMember] [DefaultValue(1313)] public override double F { get; set; } = 1313;
         [DataMember] [DefaultValue(0)] public override double V { get; set; }
-        public override double Capacity => CalcCapacity();
-        public override double CapacityFactor => OFF_PV;
+        [JsonIgnore] public override double Capacity => CalcCapacity();
+        [JsonIgnore] public override double CapacityFactor => OFF_PV;
 
         private double CalcCapacity()
         {

--- a/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
+using DistrictEnergy.ViewModels;
 using LiveCharts.Defaults;
 using Newtonsoft.Json;
 
@@ -47,7 +48,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(1313)] public override double F { get; set; } = 1313;
         [DataMember] [DefaultValue(0)] public override double V { get; set; }
         [JsonIgnore] public override double Capacity => CalcCapacity();
-        [JsonIgnore] public override double CapacityFactor => OFF_PV;
+        [JsonIgnore] public override double CapacityFactor
+        {
+            get => OFF_PV;
+            set => ElectricGenerationViewModel.Instance.OFF_PV = value * 100;
+        }
+
         public override bool IsForced { get; set; }
 
         private double CalcCapacity()

--- a/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/PhotovoltaicArray.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
 using LiveCharts.Defaults;
+using Newtonsoft.Json;
 
 namespace DistrictEnergy.Networks.ThermalPlants
 {
@@ -47,6 +48,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(0)] public override double V { get; set; }
         [JsonIgnore] public override double Capacity => CalcCapacity();
         [JsonIgnore] public override double CapacityFactor => OFF_PV;
+        public override bool IsForced { get; set; }
 
         private double CalcCapacity()
         {

--- a/DistrictEnergy/Networks/ThermalPlants/SolarThermalCollector.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/SolarThermalCollector.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
+using DistrictEnergy.ViewModels;
 using LiveCharts.Defaults;
 using Newtonsoft.Json;
 
@@ -51,7 +52,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(7191)] public override double F { get; set; } = 7191;
         [DataMember] [DefaultValue(0.00887)] public override double V { get; set; } = 0.00887;
         public override double Capacity => CalcCapacity();
-        public override double CapacityFactor => OFF_SHW;
+        public override double CapacityFactor
+        {
+            get => OFF_SHW;
+            set => HotWaterViewModel.Instance.OFF_SHW = value * 100;
+        }
+
         public override bool IsForced { get; set; }
 
         private double CalcCapacity()

--- a/DistrictEnergy/Networks/ThermalPlants/SolarThermalCollector.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/SolarThermalCollector.cs
@@ -52,6 +52,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(0.00887)] public override double V { get; set; } = 0.00887;
         public override double Capacity => CalcCapacity();
         public override double CapacityFactor => OFF_SHW;
+        public override bool IsForced { get; set; }
 
         private double CalcCapacity()
         {

--- a/DistrictEnergy/Networks/ThermalPlants/Storage.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Storage.cs
@@ -31,7 +31,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public GraphCost FixedCost => new FixedCost(this);
         public GraphCost VariableCost => new VariableCost(this, 200);
         public double TotalCost => FixedCost.Cost + VariableCost.Cost;
-        public double CapacityFactor => 1;
+        public double CapacityFactor
+        {
+            get => 1;
+            set => throw new NotImplementedException();
+        }
+
         public bool IsForced { get; set; }
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/Storage.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/Storage.cs
@@ -32,5 +32,6 @@ namespace DistrictEnergy.Networks.ThermalPlants
         public GraphCost VariableCost => new VariableCost(this, 200);
         public double TotalCost => FixedCost.Cost + VariableCost.Cost;
         public double CapacityFactor => 1;
+        public bool IsForced { get; set; }
     }
 }

--- a/DistrictEnergy/Networks/ThermalPlants/WindTurbine.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/WindTurbine.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using System.Threading;
 using System.Windows.Media;
 using DistrictEnergy.Helpers;
+using DistrictEnergy.ViewModels;
 using LiveCharts.Defaults;
 
 namespace DistrictEnergy.Networks.ThermalPlants
@@ -61,7 +62,12 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(1347)] public override double F { get; set; } = 1347;
         [DataMember] [DefaultValue(0)] public override double V { get; set; }
         public override double Capacity => CalcCapacity();
-        public override double CapacityFactor => OFF_WND;
+        public override double CapacityFactor
+        {
+            get => OFF_WND;
+            set => ElectricGenerationViewModel.Instance.OFF_WND = value * 100;
+        }
+
         public override bool IsForced { get; set; }
 
         private double CalcCapacity()

--- a/DistrictEnergy/Networks/ThermalPlants/WindTurbine.cs
+++ b/DistrictEnergy/Networks/ThermalPlants/WindTurbine.cs
@@ -62,6 +62,7 @@ namespace DistrictEnergy.Networks.ThermalPlants
         [DataMember] [DefaultValue(0)] public override double V { get; set; }
         public override double Capacity => CalcCapacity();
         public override double CapacityFactor => OFF_WND;
+        public override bool IsForced { get; set; }
 
         private double CalcCapacity()
         {

--- a/DistrictEnergy/ViewModels/ACustomModuleViewModel.cs
+++ b/DistrictEnergy/ViewModels/ACustomModuleViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Windows.Media;
 using DistrictEnergy.Networks.ThermalPlants;
@@ -112,15 +112,23 @@ namespace DistrictEnergy.ViewModels
         {
             get
             {
-
-                    return DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>()
-                        .First(x => x.Id == Id).Color;
-                
+                return DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>()
+                    .First(x => x.Id == Id).Color;
             }
             set
             {
                 DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>().First(x => x.Id == Id)
                     .Color = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsForced
+        {
+            get => DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>().First(x => x.Id == Id).IsForced;
+            set
+            {
+                DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>().First(x => x.Id == Id).IsForced = value;
                 OnPropertyChanged();
             }
         }

--- a/DistrictEnergy/ViewModels/ACustomModuleViewModel.cs
+++ b/DistrictEnergy/ViewModels/ACustomModuleViewModel.cs
@@ -85,14 +85,14 @@ namespace DistrictEnergy.ViewModels
             }
         }
 
-        public double Norm
+        public double CapacityFactor
         {
             get
             {
                 try
                 {
                     return DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>()
-                        .First(x => x.Id == Id).Norm * 100;
+                        .First(x => x.Id == Id).CapacityFactor * 100;
                 }
                 catch (Exception e)
                 {
@@ -103,7 +103,7 @@ namespace DistrictEnergy.ViewModels
             set
             {
                 DistrictControl.Instance.ListOfPlantSettings.OfType<CustomEnergySupplyModule>().First(x => x.Id == Id)
-                    .Norm = value / 100;
+                    .OFF_Custom = value / 100;
                 OnPropertyChanged();
             }
         }

--- a/DistrictEnergy/ViewModels/ChilledWaterViewModel.cs
+++ b/DistrictEnergy/ViewModels/ChilledWaterViewModel.cs
@@ -6,8 +6,6 @@ namespace DistrictEnergy.ViewModels
 {
     public class ChilledWaterViewModel : PlantSettingsViewModel
     {
-        private double _absChillerCapacity;
-
         public ChilledWaterViewModel()
         {
             Instance = this;
@@ -87,6 +85,16 @@ namespace DistrictEnergy.ViewModels
             set
             {
                 DistrictControl.Instance.ListOfPlantSettings.OfType<AbsorptionChiller>().First().V = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsForced_ABS
+        {
+            get => DistrictControl.Instance.ListOfPlantSettings.OfType<AbsorptionChiller>().First().IsForced;
+            set
+            {
+                DistrictControl.Instance.ListOfPlantSettings.OfType<AbsorptionChiller>().First().IsForced = value;
                 OnPropertyChanged();
             }
         }

--- a/DistrictEnergy/ViewModels/CombinedHeatAndPowerViewModel.cs
+++ b/DistrictEnergy/ViewModels/CombinedHeatAndPowerViewModel.cs
@@ -80,5 +80,15 @@ namespace DistrictEnergy.ViewModels
                 OnPropertyChanged();
             }
         }
+
+        public bool IsForced_CHP
+        {
+            get => DistrictControl.Instance.ListOfPlantSettings.OfType<CombinedHeatNPower>().First().IsForced;
+            set
+            {
+                DistrictControl.Instance.ListOfPlantSettings.OfType<CombinedHeatNPower>().First().IsForced = value;
+                OnPropertyChanged();
+            }
+        }
     }
 }

--- a/DistrictEnergy/ViewModels/ElectricGenerationViewModel.cs
+++ b/DistrictEnergy/ViewModels/ElectricGenerationViewModel.cs
@@ -78,6 +78,16 @@ namespace DistrictEnergy.ViewModels
             }
         }
 
+        public bool IsForced_PV
+        {
+            get => DistrictControl.Instance.ListOfPlantSettings.OfType<PhotovoltaicArray>().First().IsForced;
+            set
+            {
+                DistrictControl.Instance.ListOfPlantSettings.OfType<PhotovoltaicArray>().First().IsForced = value;
+                OnPropertyChanged();
+            }
+        }
+
         #endregion
 
         #region Wind
@@ -158,6 +168,16 @@ namespace DistrictEnergy.ViewModels
             set
             {
                 DistrictControl.Instance.ListOfPlantSettings.OfType<WindTurbine>().First().V = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsForced_WND
+        {
+            get => DistrictControl.Instance.ListOfPlantSettings.OfType<WindTurbine>().First().IsForced;
+            set
+            {
+                DistrictControl.Instance.ListOfPlantSettings.OfType<WindTurbine>().First().IsForced = value;
                 OnPropertyChanged();
             }
         }

--- a/DistrictEnergy/ViewModels/HotWaterViewModel.cs
+++ b/DistrictEnergy/ViewModels/HotWaterViewModel.cs
@@ -117,6 +117,16 @@ namespace DistrictEnergy.ViewModels
             }
         }
 
+        public bool IsForced_EHP
+        {
+            get => DistrictControl.Instance.ListOfPlantSettings.OfType<ElectricHeatPump>().First().IsForced;
+            set
+            {
+                DistrictControl.Instance.ListOfPlantSettings.OfType<ElectricHeatPump>().First().IsForced = value;
+                OnPropertyChanged();
+            }
+        }
+
         #endregion
 
         #region HWSto
@@ -225,6 +235,16 @@ namespace DistrictEnergy.ViewModels
             set
             {
                 DistrictControl.Instance.ListOfPlantSettings.OfType<SolarThermalCollector>().First().V = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsForced_SHW
+        {
+            get => DistrictControl.Instance.ListOfPlantSettings.OfType<SolarThermalCollector>().First().IsForced;
+            set
+            {
+                DistrictControl.Instance.ListOfPlantSettings.OfType<SolarThermalCollector>().First().IsForced = value;
                 OnPropertyChanged();
             }
         }

--- a/DistrictEnergy/ViewModels/LoadsViewModel.cs
+++ b/DistrictEnergy/ViewModels/LoadsViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/DistrictEnergy/Views/PlantSettings/ACustomModuleView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/ACustomModuleView.xaml
@@ -62,10 +62,10 @@
                             <ColumnDefinition Width="Auto" MinWidth="30" />
                             <ColumnDefinition Width="Auto" MinWidth="40" />
                         </Grid.ColumnDefinitions>
-                        <Slider VerticalAlignment="Center" Maximum="300" Minimum="-300" x:Name="SliderA"
-                                Value="{Binding Norm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                ToolTip="Capacity as percent of peak cooling load"
-                                IsSnapToTickEnabled="True" Focusable="False" />
+                        <Slider VerticalAlignment="Center" Maximum="100" Minimum="0" x:Name="SliderA"
+                                Value="{Binding CapacityFactor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                ToolTip="Capacity as percent of total energy"
+                                IsSnapToTickEnabled="True" Focusable="False" Margin="10,0,0,0" />
 
                         <StackPanel Orientation="Horizontal" Grid.Column="1"
                                     Grid.ColumnSpan="2"
@@ -74,8 +74,8 @@
                                    VerticalContentAlignment="Center"
                                    HorizontalAlignment="Center" />
                             <TextBox
-                                Text="{Binding Norm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                UndoLimit="10" />
+                                Text="{Binding CapacityFactor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                UndoLimit="10" MinWidth="35" />
                         </StackPanel>
                     </Grid>
                     <Grid Margin="0,8,0,0" VerticalAlignment="Top">

--- a/DistrictEnergy/Views/PlantSettings/ACustomModuleView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/ACustomModuleView.xaml
@@ -56,18 +56,22 @@
                 </Expander.Header>
                 <StackPanel>
                     <materialDesign:ColorPicker Color="{Binding Color}" HueSliderPosition="Bottom" />
-                    <Grid VerticalAlignment="Top" Panel.ZIndex="1" Height="25">
+                    <Grid VerticalAlignment="Center" Panel.ZIndex="1" Height="Auto">
                         <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition />
                             <ColumnDefinition Width="Auto" MinWidth="30" />
                             <ColumnDefinition Width="Auto" MinWidth="40" />
                         </Grid.ColumnDefinitions>
+                        <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced}">
+                            <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                        </ToggleButton>
                         <Slider VerticalAlignment="Center" Maximum="100" Minimum="0" x:Name="SliderA"
                                 Value="{Binding CapacityFactor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                 ToolTip="Capacity as percent of total energy"
-                                IsSnapToTickEnabled="True" Focusable="False" Margin="10,0,0,0" />
+                                IsSnapToTickEnabled="True" Focusable="False" Margin="10,0,0,0" Grid.Column="1" />
 
-                        <StackPanel Orientation="Horizontal" Grid.Column="1"
+                        <StackPanel Orientation="Horizontal" Grid.Column="2"
                                     Grid.ColumnSpan="2"
                                     HorizontalAlignment="Right" Margin="0">
                             <Label Content="%" Margin="0,2,3,2" Padding="3,0,0,0"

--- a/DistrictEnergy/Views/PlantSettings/ACustomModuleView.xaml.cs
+++ b/DistrictEnergy/Views/PlantSettings/ACustomModuleView.xaml.cs
@@ -19,23 +19,22 @@ namespace DistrictEnergy.Views.PlantSettings
         public ACustomModuleView(LoadTypes type)
         {
             _id = Guid.NewGuid();
-            ;
+            IThermalPlantSettings customPlant = null;
             switch (type)
             {
                 // Todo: case for each
                 case LoadTypes.Cooling:
-                    DistrictControl.Instance.ListOfPlantSettings.Add(new CustomCoolingSupplyModule()
-                        {Id = _id, Name = "New Cooling Supply Module"});
+                    customPlant = new CustomCoolingSupplyModule {Id = _id, Name = "New Cooling Supply Module"};
                     break;
                 case LoadTypes.Elec:
-                    DistrictControl.Instance.ListOfPlantSettings.Add(new CustomElectricitySupplyModule()
-                        {Id = _id, Name = "New Electricity Supply Module"});
+                    customPlant = new CustomElectricitySupplyModule {Id = _id, Name = "New Electricity Supply Module"};
                     break;
                 case LoadTypes.Heating:
-                    DistrictControl.Instance.ListOfPlantSettings.Add(new CustomHeatingSupplyModule()
-                        {Id = _id, Name = "New Heating Supply Module"});
+                    customPlant = new CustomHeatingSupplyModule {Id = _id, Name = "New Heating Supply Module"};
                     break;
             }
+
+            DistrictControl.Instance.ListOfPlantSettings.Add(customPlant);
 
             InitializeComponent();
             DataContext = new ACustomModuleViewModel() {Id = _id};
@@ -75,7 +74,8 @@ namespace DistrictEnergy.Views.PlantSettings
             }
             catch (Exception exception)
             {
-                MessageBoxResult result = MessageBox.Show(exception.Message, "An Error occured while reading the CSV file");
+                MessageBoxResult result =
+                    MessageBox.Show(exception.Message, "An Error occured while reading the CSV file");
                 RhinoApp.WriteLine(exception.Message);
             }
         }

--- a/DistrictEnergy/Views/PlantSettings/ChilledWaterView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/ChilledWaterView.xaml
@@ -64,27 +64,27 @@
                     <StackPanel Grid.Row="1">
                         <Expander BorderBrush="{DynamicResource MaterialDesignBody}">
                             <Expander.Header>
-                                <Grid VerticalAlignment="Top" Panel.ZIndex="1">
+                                <Grid VerticalAlignment="Top" Panel.ZIndex="1" Margin="-15,0,0,0">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" MinWidth="30" />
-                                        <ColumnDefinition Width="Auto" MinWidth="40" />
+                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_ABS}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                        <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                                    </ToggleButton>
                                     <Slider VerticalAlignment="Center" Maximum="100" x:Name="SliderA"
                                             Value="{Binding OFF_ABS, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="Capacity factor as ratio of the total cooling energy supplied by the energy hub"
-                                            IsSnapToTickEnabled="True" Focusable="False" />
+                                            IsSnapToTickEnabled="True" Focusable="False" Grid.Column="1" Margin="10,0" />
 
-                                    <StackPanel Orientation="Horizontal" Grid.Column="1"
+                                    <StackPanel Orientation="Horizontal" Grid.Column="2"
                                                 Grid.ColumnSpan="2"
-                                                HorizontalAlignment="Right" Margin="0">
+                                                HorizontalAlignment="Right" Margin="0" VerticalAlignment="Center">
                                         <Label Content="%" Margin="0,2,3,2" Padding="3,0,0,0"
                                                VerticalContentAlignment="Center"
                                                HorizontalAlignment="Center" />
-                                        <TextBox
-                                            Text="{Binding OFF_ABS, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                            UndoLimit="10" />
-
+                                        <TextBox Text="{Binding OFF_ABS, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" UndoLimit="10" />
                                     </StackPanel>
                                 </Grid>
                             </Expander.Header>

--- a/DistrictEnergy/Views/PlantSettings/CombinedHeatAndPowerView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/CombinedHeatAndPowerView.xaml
@@ -23,25 +23,11 @@
                 <ResourceDictionary
                     Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
                 <ResourceDictionary
-                    Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                    Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/materialdesigncolor.bluegrey.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
-        <!--<Style x:Key="PlantComponentHeader" TargetType="{x:Type TextBlock}">
-            <Setter Property="TextWrapping" Value="NoWrap" />
-            <Setter Property="TextTrimming" Value="None" />
-            <Setter Property="Margin" Value="5, 5" />
-            <Setter Property="FontSize" Value="14" />
-            <Setter Property="Foreground" Value="#404040" />
-        </Style>
-        <Style x:Key="StackPanelStyle" TargetType="StackPanel">
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="VerticalAlignment" Value="Top" />
-            <Setter Property="Width" Value="Auto" />
-            <Setter Property="Margin" Value="5,0,5,5" />
-            <Setter Property="Background" Value="White" />
-        </Style>-->
     </UserControl.Resources>
     <Grid x:Name="ChpGroup">
         <GroupBox Margin="4" Style="{DynamicResource MaterialDesignCardGroupBox}"
@@ -77,25 +63,28 @@
                     <StackPanel Grid.Row="1">
                         <Expander>
                             <Expander.Header>
-                                <Grid VerticalAlignment="Top" Panel.ZIndex="1">
+                                <Grid VerticalAlignment="Top" Panel.ZIndex="1" Margin="-15,0,0,0">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" MinWidth="30" />
-                                        <ColumnDefinition Width="Auto" MinWidth="40" />
+                                        <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <Slider VerticalAlignment="Center" Margin="0" Maximum="100"
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_CHP}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                        <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                                    </ToggleButton>
+                                    <Slider VerticalAlignment="Center" Margin="10,0" Maximum="100"
                                             Value="{Binding OFF_CHP, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="Capacity factor as ratio of the total heating OR electricity energy supplied by the energy hub. See Tracking Mode."
-                                            IsSnapToTickEnabled="True" Focusable="False" />
-                                    <StackPanel Orientation="Horizontal" Grid.Column="1"
+                                            IsSnapToTickEnabled="True" Focusable="False" Grid.Column="1" />
+                                    <StackPanel Orientation="Horizontal" Grid.Column="2"
 
-                                                HorizontalAlignment="Right" Margin="0" Grid.ColumnSpan="2">
+                                                HorizontalAlignment="Right" Margin="0">
                                         <Label Content="%" Margin="0,2,3,2" Padding="3,0,0,0"
                                                VerticalContentAlignment="Center"
                                                HorizontalAlignment="Center" />
                                         <TextBox
                                             Text="{Binding OFF_CHP, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                            Margin="0,0,1,0" />
+                                            Margin="0,0,1,0" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" />
                                     </StackPanel>
                                 </Grid>
                             </Expander.Header>

--- a/DistrictEnergy/Views/PlantSettings/ElectricGenerationView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/ElectricGenerationView.xaml
@@ -187,7 +187,7 @@
                                         <ColumnDefinition />
                                         <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
-                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_WND}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_WND}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results" Visibility="Hidden">
                                         <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
                                     </ToggleButton>
                                     <Slider VerticalAlignment="Center" Margin="10,0" Maximum="100"

--- a/DistrictEnergy/Views/PlantSettings/ElectricGenerationView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/ElectricGenerationView.xaml
@@ -64,16 +64,19 @@
                     <StackPanel Grid.Row="1">
                         <Expander>
                             <Expander.Header>
-                                <Grid VerticalAlignment="Top" Panel.ZIndex="1">
+                                <Grid VerticalAlignment="Top" Panel.ZIndex="1" Margin="-15,0,0,0">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" MinWidth="30" />
-                                        <ColumnDefinition Width="Auto" MinWidth="40" />
+                                        <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_PV}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                        <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                                    </ToggleButton>
                                     <Slider VerticalAlignment="Center" Maximum="100"
                                             Value="{Binding OFF_PV, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="Capacity factor as ratio of the total electricity energy supplied by the energy hub"
-                                            IsSnapToTickEnabled="True" Focusable="False" />
+                                            IsSnapToTickEnabled="True" Focusable="False" Grid.Column="1" Margin="10,0" />
                                     <StackPanel Orientation="Horizontal" Grid.Column="1"
                                                 Grid.ColumnSpan="2"
                                                 HorizontalAlignment="Right" Margin="0">
@@ -178,18 +181,20 @@
                     <StackPanel Grid.Row="1">
                         <Expander>
                             <Expander.Header>
-                                <Grid VerticalAlignment="Top" Panel.ZIndex="1">
+                                <Grid VerticalAlignment="Top" Panel.ZIndex="1" Margin="-15,0,0,0">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" MinWidth="30" />
-                                        <ColumnDefinition Width="Auto" MinWidth="40" />
+                                        <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
-                                    <Slider VerticalAlignment="Center" Margin="0" Maximum="100"
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_WND}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                        <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                                    </ToggleButton>
+                                    <Slider VerticalAlignment="Center" Margin="10,0" Maximum="100"
                                             Value="{Binding OFF_WND, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="Capacity factor as ratio of the total electricity energy supplied by the energy hub"
-                                            IsSnapToTickEnabled="True" Focusable="False" />
-                                    <StackPanel Orientation="Horizontal" Grid.Column="1"
-                                                Grid.ColumnSpan="2"
+                                            IsSnapToTickEnabled="True" Focusable="False" Grid.Column="1" />
+                                    <StackPanel Orientation="Horizontal" Grid.Column="2"
                                                 HorizontalAlignment="Right" Margin="0">
                                         <Label Content="%" Margin="0,2,3,2" Padding="3,0,0,0"
                                                VerticalContentAlignment="Center"
@@ -338,18 +343,20 @@
                     <StackPanel Grid.Row="1">
                         <Expander>
                             <Expander.Header>
-                                <Grid VerticalAlignment="Top" Panel.ZIndex="1">
+                                <Grid VerticalAlignment="Top" Panel.ZIndex="1" Margin="-15,0,0,0">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" MinWidth="50" />
-                                        <ColumnDefinition Width="Auto" MinWidth="40" />
+                                        <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
-                                    <Slider VerticalAlignment="Center" Margin="0" Maximum="365"
+                                    <!--<ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_ABS}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                        <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                                    </ToggleButton>-->
+                                    <Slider VerticalAlignment="Center" Margin="50,0,10,0" Maximum="365"
                                             Value="{Binding AUT_BAT, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="Number of average annual days that batteries can meet demand once fully charged"
-                                            IsSnapToTickEnabled="True" />
-                                    <StackPanel Orientation="Horizontal" Grid.Column="1"
-                                                Grid.ColumnSpan="2"
+                                            IsSnapToTickEnabled="True" Grid.Column="1" />
+                                    <StackPanel Orientation="Horizontal" Grid.Column="2"
                                                 HorizontalAlignment="Right" Margin="0">
                                         <Label Content="n days"
                                                VerticalContentAlignment="Center"

--- a/DistrictEnergy/Views/PlantSettings/ElectricGenerationView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/ElectricGenerationView.xaml
@@ -70,7 +70,7 @@
                                         <ColumnDefinition />
                                         <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
-                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_PV}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_PV}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results" Visibility="Hidden">
                                         <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
                                     </ToggleButton>
                                     <Slider VerticalAlignment="Center" Maximum="100"

--- a/DistrictEnergy/Views/PlantSettings/HotWaterView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/HotWaterView.xaml
@@ -65,24 +65,27 @@
                     <StackPanel Grid.Row="1">
                         <Expander>
                             <Expander.Header>
-                                <Grid VerticalAlignment="Top" Panel.ZIndex="1">
+                                <Grid VerticalAlignment="Top" Panel.ZIndex="1" Margin="-15,0,0,0">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" MinWidth="30" />
-                                        <ColumnDefinition Width="Auto" MinWidth="40" />
+                                        <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
-                                    <Slider VerticalAlignment="Center" Margin="0" Maximum="100"
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_EHP}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                        <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                                    </ToggleButton>
+                                    <Slider VerticalAlignment="Center" Margin="10,0" Maximum="100"
                                             Value="{Binding OFF_EHP, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="Capacity factor as ratio of the total heating energy supplied by the energy hub"
-                                            IsSnapToTickEnabled="True" Focusable="False" />
-                                    <StackPanel Orientation="Horizontal" Grid.Column="1"
+                                            IsSnapToTickEnabled="True" Focusable="False" Grid.Column="1" />
+                                    <StackPanel Orientation="Horizontal" Grid.Column="2"
                                                 Grid.ColumnSpan="2"
                                                 HorizontalAlignment="Right" Margin="0">
                                         <Label Content="%" Margin="0,2,3,2" Padding="3,0,0,0"
                                                VerticalContentAlignment="Center"
                                                HorizontalAlignment="Center" />
                                         <TextBox
-                                            Text="{Binding OFF_EHP, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                            Text="{Binding OFF_EHP, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
                                     </StackPanel>
                                 </Grid>
 
@@ -167,24 +170,26 @@
 
                         <Expander>
                             <Expander.Header>
-                                <Grid VerticalAlignment="Top" Panel.ZIndex="1">
+                                <Grid VerticalAlignment="Top" Panel.ZIndex="1" Margin="-15,0,0,0">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" MinWidth="30" />
-                                        <ColumnDefinition Width="Auto" MinWidth="40" />
+                                        <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
-                                    <Slider VerticalAlignment="Center" Margin="0" Maximum="100"
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_SHW}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                        <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                                    </ToggleButton>
+                                    <Slider VerticalAlignment="Center" Margin="10,0" Maximum="100"
                                             Value="{Binding OFF_SHW, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="Capacity factor as ratio of the total heating energy supplied by the energy hub"
-                                            IsSnapToTickEnabled="True" Focusable="False" />
-                                    <StackPanel Orientation="Horizontal" Grid.Column="1"
-                                                Grid.ColumnSpan="2"
+                                            IsSnapToTickEnabled="True" Focusable="False" Grid.Column="1" />
+                                    <StackPanel Orientation="Horizontal" Grid.Column="2"
                                                 HorizontalAlignment="Right" Margin="0">
                                         <Label Content="%" Margin="0,2,3,2" Padding="3,0,0,0"
                                                VerticalContentAlignment="Center"
                                                HorizontalAlignment="Center" />
                                         <TextBox
-                                            Text="{Binding OFF_SHW, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                            Text="{Binding OFF_SHW, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
                                     </StackPanel>
                                 </Grid>
 
@@ -294,23 +299,25 @@
                     <StackPanel Grid.Row="1">
                         <Expander>
                             <Expander.Header>
-                                <Grid VerticalAlignment="Top" Panel.ZIndex="1">
+                                <Grid VerticalAlignment="Top" Panel.ZIndex="1" Margin="-15,0,0,0">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" MinWidth="30" />
-                                        <ColumnDefinition Width="Auto" MinWidth="40" />
+                                        <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
-                                    <Slider VerticalAlignment="Center" Margin="0" Maximum="365"
+                                    <!--<ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_ABS}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                        <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
+                                    </ToggleButton>-->
+                                    <Slider VerticalAlignment="Center" Margin="50,0,10,0" Maximum="365"
                                             Value="{Binding AUT_HWT, BindsDirectlyToSource=True, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="Number of average annual days that tanks can meet demand once fully charged"
-                                            IsSnapToTickEnabled="True" Focusable="False" />
-                                    <StackPanel Orientation="Horizontal" Grid.Column="1"
-                                                Grid.ColumnSpan="2"
+                                            IsSnapToTickEnabled="True" Focusable="False" Grid.Column="1" />
+                                    <StackPanel Orientation="Horizontal" Grid.Column="2"
                                                 HorizontalAlignment="Right" Margin="0">
                                         <Label Content="n days" Margin="0,2,3,2" Padding="3,0,0,0"
                                                VerticalContentAlignment="Center"
                                                HorizontalAlignment="Center" />
-                                        <TextBox x:Name="AutHwt">
+                                        <TextBox x:Name="AutHwt" VerticalAlignment="Center">
                                             <TextBox.Text>
                                                 <Binding Path="AUT_HWT" BindsDirectlyToSource="True"
                                                          Mode="TwoWay"

--- a/DistrictEnergy/Views/PlantSettings/HotWaterView.xaml
+++ b/DistrictEnergy/Views/PlantSettings/HotWaterView.xaml
@@ -176,7 +176,7 @@
                                         <ColumnDefinition />
                                         <ColumnDefinition Width="Auto" MinWidth="60" />
                                     </Grid.ColumnDefinitions>
-                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_SHW}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results">
+                                    <ToggleButton Style="{DynamicResource MaterialDesignFlatToggleButton}" Height="40" IsChecked="{Binding IsForced_SHW}" ToolTip="Force this supply module to meet the specfied ratio of the total demand despite the optimization results" Visibility="Hidden">
                                         <materialDesign:PackIcon Kind="Lock"></materialDesign:PackIcon>
                                     </ToggleButton>
                                     <Slider VerticalAlignment="Center" Margin="10,0" Maximum="100"


### PR DESCRIPTION
Clicking the lock icon will force the solver to use this equipment to its specified capacity. This could result in a sub-optimal solution.